### PR TITLE
fix:start to look at why build is failing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+          CIBW_ARCHS_LINUX: auto64 aarch64 ppc64le s390x
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,12 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS_LINUX: auto64 aarch64 ppc64le s390x
+          CIBW_ARCHS_LINUX: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-11]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,6 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,13 +16,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-22.04, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-22.04, macos-12]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel.windows]
 archs=["AMD64"]
 before-all = "powershell {project}\\installGo.ps1"
-skip = "cp36-win* pp310-manylinux_x86_64"
+skip = "cp36-win*"
 environment= """
 PATH="C:\\Go\\bin;C:\\Program Files\\Go\\bin;$PATH"
 GOPATH="C:\\Go"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ GOPATH="C:\\Go"
 [tool.cibuildwheel.linux]
 archs=["x86_64"]
 before-all = '''
+sed_escape()
+{
+	# Note: this is not a full implementation
+	echo -n "$1" | sed -e 's|\.|\\.|g'
+}
 switch_eol_centos_repos()
 {
 	local old_mirrorlist_host="mirrorlist.centos.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ GOPATH="C:\\Go"
 
 [tool.cibuildwheel.linux]
 archs=["x86_64"]
-#before-all = "yum install -y golang"
+before-all = "yum install -y golang"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ GOPATH="C:\\Go"
 
 [tool.cibuildwheel.linux]
 archs=["x86_64"]
-before-all = """
+before-all = '''
 switch_eol_centos_repos()
 {
 	local old_mirrorlist_host="mirrorlist.centos.org"
@@ -30,7 +30,7 @@ switch_eol_centos_repos()
 	echo "YUM package manager repositories were backed up to '$backup' and switched from $old_host to $new_host ." >&2
 }
 switch_eol_centos_repos
-yum install -y golang"""
+yum install -y golang'''
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,19 +20,16 @@ sed_escape()
 }
 switch_eol_centos_repos()
 {
-	local old_mirrorlist_host="mirrorlist.centos.org"
-	local old_host="mirror.centos.org"
-	local new_host="vault.centos.org"
-
-	grep -qFw "$old_host" /etc/yum.repos.d/CentOS-*.repo 2>/dev/null || return 0
-	local backup="`mktemp -d "/tmp/yum.repos.d-$(date --rfc-3339=date)-XXXXXX"`"
-	! [ -d "$backup" ] || cp -raT /etc/yum.repos.d "$backup" || :
-
-	sed -i \
-		-e "s|^\s*\(mirrorlist\b[^/]*//`sed_escape "$old_mirrorlist_host"`/.*\)$|#\1|" \
-		-e "s|^#*\s*baseurl\b\([^/]*\)//`sed_escape "$old_host"`/\(.*\)$|baseurl\1//$new_host/\2|" \
-		/etc/yum.repos.d/CentOS-*.repo
-	echo "YUM package manager repositories were backed up to '$backup' and switched from $old_host to $new_host ." >&2
+	if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] && [ "${AUDITWHEEL_ARCH}" != "s390x" ]; then
+		# Centos 7 is EOL and is no longer available from the usual mirrors, so switch
+		# to https://vault.centos.org
+		sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+		sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+		sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+		if [ "${AUDITWHEEL_ARCH}" == "aarch64" ] || [ "${AUDITWHEEL_ARCH}" == "ppc64le" ]; then
+			sed -i 's;/centos/7/;/altarch/7/;g' /etc/yum.repos.d/*.repo
+		fi
+	fi
 }
 switch_eol_centos_repos
 yum install -y golang'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,6 @@ GOPATH="C:\\Go"
 [tool.cibuildwheel.linux]
 archs=["x86_64"]
 before-all = '''
-sed_escape()
-{
-	# Note: this is not a full implementation
-	echo -n "$1" | sed -e 's|\.|\\.|g'
-}
 switch_eol_centos_repos()
 {
 	if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] && [ "${AUDITWHEEL_ARCH}" != "s390x" ]; then
@@ -32,7 +27,11 @@ switch_eol_centos_repos()
 	fi
 }
 switch_eol_centos_repos
-yum install -y golang'''
+if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]
+then
+	yum install -y golang
+fi
+'''
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ GOPATH="C:\\Go"
 
 [tool.cibuildwheel.linux]
 archs=["x86_64"]
-before-all = "yum install -y golang"
+#before-all = "yum install -y golang"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel.windows]
 archs=["AMD64"]
 before-all = "powershell {project}\\installGo.ps1"
-skip = "cp36-win*"
+skip = "cp36-win* pp310-*"
 environment= """
 PATH="C:\\Go\\bin;C:\\Program Files\\Go\\bin;$PATH"
 GOPATH="C:\\Go"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel.windows]
 archs=["AMD64"]
 before-all = "powershell {project}\\installGo.ps1"
-skip = "cp36-win* pp310-*"
+skip = "cp36-win* pp310-manylinux_x86_64"
 environment= """
 PATH="C:\\Go\\bin;C:\\Program Files\\Go\\bin;$PATH"
 GOPATH="C:\\Go"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,25 @@ GOPATH="C:\\Go"
 
 [tool.cibuildwheel.linux]
 archs=["x86_64"]
-before-all = "yum install -y golang"
+before-all = """
+switch_eol_centos_repos()
+{
+	local old_mirrorlist_host="mirrorlist.centos.org"
+	local old_host="mirror.centos.org"
+	local new_host="vault.centos.org"
+
+	grep -qFw "$old_host" /etc/yum.repos.d/CentOS-*.repo 2>/dev/null || return 0
+	local backup="`mktemp -d "/tmp/yum.repos.d-$(date --rfc-3339=date)-XXXXXX"`"
+	! [ -d "$backup" ] || cp -raT /etc/yum.repos.d "$backup" || :
+
+	sed -i \
+		-e "s|^\s*\(mirrorlist\b[^/]*//`sed_escape "$old_mirrorlist_host"`/.*\)$|#\1|" \
+		-e "s|^#*\s*baseurl\b\([^/]*\)//`sed_escape "$old_host"`/\(.*\)$|baseurl\1//$new_host/\2|" \
+		/etc/yum.repos.d/CentOS-*.repo
+	echo "YUM package manager repositories were backed up to '$backup' and switched from $old_host to $new_host ." >&2
+}
+switch_eol_centos_repos
+yum install -y golang"""
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"


### PR DESCRIPTION
Root cause of issue is manywheeels used to build is centos7 based. Thats gone eol so centos team moved the mirror to vault dns name. This solves the immediate issue need to look at whats happening in many linux land on this to see if longer term fix needed.

Still active manylinux they indeed fixed in https://github.com/pypa/manylinux/pull/1628
but this drops python versions so likely using old for unnsupported python versions so given this uses cibuildwheel and that drives matrix need to now look at eol dates and restricting to supported as well