### PR TITLE
feat: handle distutils deprecation in python 3.12 sysconfig has exist…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pygobuildinfo
-version = 0.1.18
+version = 0.1.19
 author = Mike Moore
 author_email = z_z_zebra@yahoo.com
 license = MIT

--- a/src/pygobuildinfo/__init__.py
+++ b/src/pygobuildinfo/__init__.py
@@ -12,7 +12,9 @@ __all__ = [
 import ctypes
 import json
 import os
-from distutils.sysconfig import get_config_var
+
+from sysconfig import get_config_var
+
 from pathlib import Path
 
 


### PR DESCRIPTION
…ed since 3.2 we only support supported versions i.e. 3.8+